### PR TITLE
fix: add EDEN checkout to release and javadoc deploy jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+    env:
+      EDEN_PATH: _eden
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -69,6 +71,19 @@ jobs:
         uses: ./.github/actions/common-setup
         with:
           java-version: 26
+
+      - name: Checkout EDEN
+        uses: actions/checkout@v4
+        with:
+          repository: StoryTime-Productions/EDEN
+          path: _eden
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build EDEN
+        working-directory: _eden
+        run: |
+          chmod +x gradlew
+          ./gradlew build --no-daemon
 
       - name: Publish with Gradle
         run: ./gradlew -Pver="0.0.0-RC-1" release

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,6 +20,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    env:
+      EDEN_PATH: _eden
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -35,6 +37,19 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+
+      - name: Checkout EDEN
+        uses: actions/checkout@v4
+        with:
+          repository: StoryTime-Productions/EDEN
+          path: _eden
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build EDEN
+        working-directory: _eden
+        run: |
+          chmod +x gradlew
+          ./gradlew build --no-daemon
 
       - name: Generate Javadoc
         run: ./gradlew javadoc


### PR DESCRIPTION
## Summary
- `release` job and `static.yml` deploy job were missing the EDEN checkout+build steps
- Only the `test` job had them, so `./gradlew release` and `./gradlew javadoc` both failed with `package com.storytimeproductions.eden does not exist`

## Changes
- Added EDEN checkout and build steps to `release` job in `main.yml`
- Added EDEN checkout and build steps to `deploy` job in `static.yml`

## Test plan
- [x] Merge and verify all three jobs pass on next push to main