### PR TITLE
fix: revert EDEN_PATH default to single-level after flattening repo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Contributions, ideas, or feature requests are always welcome!
 
 - Gradle (or the included `gradlew` / `gradlew.bat` wrapper)
 - Java 26: set `JAVA_HOME` accordingly
-- A local build of [EDEN](https://github.com/StoryTime-Productions/EDEN) (defaults to `../../EDEN`, or set the `EDEN_PATH` environment variable to point elsewhere)
+- A local build of [EDEN](https://github.com/StoryTime-Productions/EDEN) (defaults to `../EDEN`, or set the `EDEN_PATH` environment variable to point elsewhere)
 - PowerShell 5.1+ (for Windows users): used for deployment zip compression
 - A `.env` file in the project root defining:
   ```env

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     compileOnly 'net.dmulloy2:ProtocolLib:5.4.0'
     compileOnly 'me.libraryaddict.disguises:libsdisguises:11.0.16'
     compileOnly 'com.github.retrooper:packetevents-spigot:2.12.1'
-    compileOnly fileTree(dir: "${System.getenv('EDEN_PATH') ?: '../../EDEN'}/build/libs", include: 'EDEN-*-SNAPSHOT.jar')
+    compileOnly fileTree(dir: "${System.getenv('EDEN_PATH') ?: '../EDEN'}/build/libs", include: 'EDEN-*-SNAPSHOT.jar')
 }
 
 test {


### PR DESCRIPTION
## Summary
- STweaks itself moved out of the Stweakss/ bundle folder to become a top-level STP/ sibling (matching EDEN and PropHunt), so the '../../EDEN' default merged in #73 (correct only while STweaks was still nested one level deeper than EDEN) is stale again. Reverts to '../EDEN'.

## Test plan
- [x] Local build with EDEN_PATH unset, relying on the '../EDEN' default from the new flat STP/Stweaks location, succeeds (compile, checkstyle, spotless, deployDatapack).